### PR TITLE
fix signature length when either r or s do not fill 32 bytes

### DIFF
--- a/src/main/java/com/bakkenbaeck/token/crypto/ECKey.java
+++ b/src/main/java/com/bakkenbaeck/token/crypto/ECKey.java
@@ -634,8 +634,8 @@ public class ECKey implements Serializable {
                     ? (byte) (this.v - 27)
                     :this.v;
 
-            final String hexR = ByteUtil.toHexString(ByteUtil.bigIntegerToBytes(this.r));
-            final String hexS = ByteUtil.toHexString(ByteUtil.bigIntegerToBytes(this.s));
+            final String hexR = ByteUtil.toZeroPaddedHexString(ByteUtil.bigIntegerToBytes(this.r), 64);
+            final String hexS = ByteUtil.toZeroPaddedHexString(ByteUtil.bigIntegerToBytes(this.s), 64);
             final String hexV = ByteUtil.toHexString(new byte[]{fixedV});
 
             return TypeConverter.toJsonHex(hexR + hexS + hexV);

--- a/src/main/java/com/bakkenbaeck/token/crypto/util/ByteUtil.java
+++ b/src/main/java/com/bakkenbaeck/token/crypto/util/ByteUtil.java
@@ -175,6 +175,17 @@ public class ByteUtil {
         return data == null ? "" : Hex.toHexString(data);
     }
 
+    public static String toZeroPaddedHexString(final byte[] data, final int size) {
+        final String hex = toHexString(data);
+        final StringBuffer sb = new StringBuffer("");
+        final int requiredPadding = size - hex.length();
+        while (sb.length() < requiredPadding) {
+            sb.append("0");
+        }
+        sb.append(hex);
+        return sb.toString();
+    }
+
     /**
      * Calculate packet length
      *


### PR DESCRIPTION
if either r or s don't fill out 32 bytes the signature generated ends up too short and is invalid.
see https://github.com/tokenbrowser/token-android-client/pull/364 for discussion