### PR TITLE
Added base64 image data uri support to "RedisSubscriber.java"

### DIFF
--- a/src/main/java/com/bakkenbaeck/token/headless/RedisSubscriber.java
+++ b/src/main/java/com/bakkenbaeck/token/headless/RedisSubscriber.java
@@ -68,12 +68,12 @@ class RedisSubscriber extends JedisPubSub {
 
                               // save the file to 'attachments/' + filename
                               int randomNum = (int)(Math.random() * 1000000);
-                              String randomFileName = ""+randomNum+".jpg";
+                              String randomFileName = ""+randomNum+".png";
                               String filePath = "attachments/" + randomFileName;
 
                               try {
                                 File outputfile = new File(filePath);
-                                ImageIO.write(img, "jpg", outputfile);
+                                ImageIO.write(img, "png", outputfile);
 
                                 attachments.add(filePath);
                                 System.out.println("Successfully saved the image to " + filePath + " and will now send in message.");

--- a/src/main/java/com/bakkenbaeck/token/headless/RedisSubscriber.java
+++ b/src/main/java/com/bakkenbaeck/token/headless/RedisSubscriber.java
@@ -79,7 +79,8 @@ class RedisSubscriber extends JedisPubSub {
                                 System.out.println("Successfully saved the image to " + filePath + " and will now send in message.");
 
                               }  catch (IOException e) {
-                                  System.out.println("Tried saving " + filePath + " but failed. Will not send this attachment.");
+                                  System.out.println(e);
+                                  System.out.println("Could not save " + filePath + " but failed. Will not send this attachment.");
                               }
                             }
 

--- a/src/main/java/com/bakkenbaeck/token/headless/RedisSubscriber.java
+++ b/src/main/java/com/bakkenbaeck/token/headless/RedisSubscriber.java
@@ -52,8 +52,6 @@ class RedisSubscriber extends JedisPubSub {
                 if (sofa.has("attachments")) {
                     for (int i = 0; i < sofa.get("attachments").size(); i++) {
                         JsonNode urlNode = sofa.get("attachments").get(i).get("url");
-                        JsonNode imgDataNode = sofa.get("attachments").get(i).get("base64data");
-                        JsonNode tempFileName = sofa.get("attachments").get(i).get("filename");
 
                         if (urlNode != null) {
                             String url = urlNode.asText();
@@ -66,7 +64,7 @@ class RedisSubscriber extends JedisPubSub {
                               byte[] imageBytes = DatatypeConverter.parseBase64Binary(base64data);
                               BufferedImage img = ImageIO.read(new ByteArrayInputStream(imageBytes));
 
-                              // save the file to 'attachments/' + filename
+                              // save the file to 'attachments/' + filename created using random int
                               int randomNum = (int)(Math.random() * 1000000);
                               String randomFileName = ""+randomNum+".png";
                               String filePath = "attachments/" + randomFileName;


### PR DESCRIPTION
Currently, to send images to a Token Browser user, the bot javascript app can only send images that are pre-saved in the /attachments folder since the headless-client treats every image URL it receives as a relative file path. If the submitted URL cannot be found within the "/attachments" folder the headless-client does not send an image.

For local development, a bot developer can get around this by generating images on the fly and saving them to a temp directory within the /attachments folder of the headless client (to do so, the developer would need to mount the /attachments folder in docker-compose.yml so the directory is visible to the bot script), but on production apps running on heroku, this temporary file saving approach doesn't work since the bot and headless client run on different dynos in two different VMs and cannot access each others' filesystems.

So, an approach was necessary whereby the bot client could simply send image data as a base64 image URI to the headless client and the latter could do the file-saving on its end. That's exactly what we have done in our repo and are submitting via this pull request.

"RedisSubscriber.java" is the only file we changed.

TODO: The headless-client creates a temp image file (with a random number as the filename) within the /attachments directory each time it receives a base64 data URI. Need to delete these files after they have successfully been uploaded and send to the token browser to prevent unnecessary clutter on the headless client file system in a production environment.